### PR TITLE
Added Twitter and Facebook meta tags. Needs completion

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,25 @@
     <meta name="author" content="Jeremy Buis Surfboard Repairs, Dunedin, New Zealand" />
     <meta name="keywords" content="Jeremy, Buis, surfing, surfboard, repair, Dunedin, New Zealand" />
     <meta name="Distribution" content="Global" />
+
+     <!-- Twitter Card data -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@publisher_handle">
+<meta name="twitter:title" content="Page Title">
+<meta name="twitter:description" content="Jeremy Buis Surfboard Repair Dunedin New Zealand">
+<meta name="twitter:creator" content="@author_handle">
+<-- Twitter Summary card images must be at least 120x120px -->
+<meta name="twitter:image" content="http://www.example.com/image.jpg">
+
+<!-- Open Graph data -->
+<meta property="og:title" content="Buis Surfcraft" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="http://www.example.com/" />
+<meta property="og:image" content="http://example.com/image.jpg" />
+<meta property="og:description" content="Jeremy Buis Surfboard Repair Dunedin New Zealand" />
+<meta property="og:site_name" content="Buis Surfcraft" />
+<meta property="fb:admins" content="Facebook numeric ID" /> 
+
     <link href="https://fonts.googleapis.com/css?family=Indie+Flower" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Dancing+Script" rel="stylesheet" />
     <link href="css/styles.css" rel="stylesheet" />


### PR DESCRIPTION
Have added two sets of "Open Graph" meta tags for Facebook and Twitter to improve search optimisation and bring Facebook results up on search profiles.

The meta tag values need to be populated with more accurate content, including the URLs, descriptions and Facebook Page IDs.

Also - Get a Twitter account!